### PR TITLE
Fix missing 'event' that broke the game in Firefox.

### DIFF
--- a/app/views/Game.coffee
+++ b/app/views/Game.coffee
@@ -441,7 +441,7 @@ class Game
 
     @addToShadowGrid(tetrimino, @shadowGridY - 1)
 
-  keyboardInput: ->
+  keyboardInput: (event) ->
     keyCodes = {
       ESC: 27
       SPACE: 32

--- a/public/javascripts/Game.js
+++ b/public/javascripts/Game.js
@@ -652,7 +652,7 @@ Game = (function() {
     return this.addToShadowGrid(tetrimino, this.shadowGridY - 1);
   };
 
-  Game.prototype.keyboardInput = function() {
+  Game.prototype.keyboardInput = function(event) {
     var keyCodes, ref;
     keyCodes = {
       ESC: 27,


### PR DESCRIPTION
I couldn't play the game in Firefox — there was a missing `event` argument. Somehow it worked in Chrome, though. Now it works in Firefox too!